### PR TITLE
Start prototyping vector iterator

### DIFF
--- a/crates/rune/src/error.rs
+++ b/crates/rune/src/error.rs
@@ -406,12 +406,22 @@ pub enum CompileError {
         existing_span: Span,
     },
     /// Error for missing local variables.
-    #[error("missing local variable `{name}`")]
+    #[error("missing variable `{name}`")]
     MissingLocal {
         /// Span where the error occured.
         span: Span,
-        /// Name of the missing local.
+        /// Name of the missing variable.
         name: String,
+    },
+    /// Error for moved local variables.
+    #[error("variable `{name}` has been moved")]
+    MovedLocal {
+        /// Span where the error occured.
+        span: Span,
+        /// Name of the moved variable.
+        name: String,
+        /// Where it was moved.
+        moved_at: Span,
     },
     /// Error for missing types.
     #[error("no type matching `{item}`")]
@@ -604,6 +614,7 @@ impl CompileError {
             Self::ParseError { error, .. } => error.span(),
             Self::VariableConflict { span, .. } => span,
             Self::MissingLocal { span, .. } => span,
+            Self::MovedLocal { span, .. } => span,
             Self::MissingType { span, .. } => span,
             Self::MissingModule { span, .. } => span,
             Self::MissingLabel { span, .. } => span,

--- a/crates/rune/src/runtime.rs
+++ b/crates/rune/src/runtime.rs
@@ -344,6 +344,14 @@ impl Runtime {
 
                         *span
                     }
+                    CompileError::MovedLocal { span, moved_at, .. } => {
+                        labels.push(
+                            Label::secondary(source_file, moved_at.start..moved_at.end)
+                                .with_message("moved here"),
+                        );
+
+                        *span
+                    }
                     error => error.span(),
                 },
                 RuntimeError::ParseError { error } => error.span(),

--- a/crates/rune/tests/test_programs.rs
+++ b/crates/rune/tests/test_programs.rs
@@ -965,3 +965,40 @@ fn test_struct_matching() {
         3,
     };
 }
+
+#[test]
+fn test_iter_drop() {
+    assert_eq! {
+        test! {
+            i64 => r#"
+            fn main() {
+                let sum = 0;
+                let values = [1, 2, 3, 4];
+
+                for v in values.iter() {
+                    break;
+                }
+
+                values.push(5);
+
+                for v in values.iter() {
+                    sum += v;
+
+                    if v == 2 {
+                        break;
+                    }
+                }
+
+                values.push(6);
+
+                for v in values.iter() {
+                    sum += v;
+                }
+
+                sum
+            }
+            "#
+        },
+        24,
+    };
+}

--- a/crates/runestick/src/macros.rs
+++ b/crates/runestick/src/macros.rs
@@ -9,6 +9,24 @@
 #[macro_export]
 macro_rules! decl_external {
     ($external:ty) => {
+        $crate::decl_internal!($external);
+
+        impl $crate::FromValue for $external {
+            fn from_value(
+                value: $crate::Value,
+                vm: &mut $crate::Vm,
+            ) -> Result<Self, $crate::VmError> {
+                let slot = value.into_external(vm)?;
+                vm.external_take::<$external>(slot)
+            }
+        }
+    };
+}
+
+/// Implement the value trait for an internal type.
+#[macro_export]
+macro_rules! decl_internal {
+    ($external:ty) => {
         impl $crate::ReflectValueType for $external {
             type Owned = $external;
 
@@ -66,16 +84,6 @@ macro_rules! decl_external {
                 vm: &mut $crate::Vm,
             ) -> Result<$crate::Value, $crate::VmError> {
                 Ok(vm.external_allocate_mut_ptr(self))
-            }
-        }
-
-        impl $crate::FromValue for $external {
-            fn from_value(
-                value: $crate::Value,
-                vm: &mut $crate::Vm,
-            ) -> Result<Self, $crate::VmError> {
-                let slot = value.into_external(vm)?;
-                vm.external_take::<$external>(slot)
             }
         }
 

--- a/crates/runestick/src/packages/vec.rs
+++ b/crates/runestick/src/packages/vec.rs
@@ -3,15 +3,41 @@
 use crate::context::{ContextError, Module};
 use crate::value::Value;
 
+/// An iterator over a vector.
+pub struct Iter {
+    iter: std::vec::IntoIter<Value>,
+}
+
+impl Iter {
+    /// Iterate over the next value.
+    pub fn next(&mut self) -> Option<Value> {
+        self.iter.next()
+    }
+}
+
+fn vec_iter(vec: &Vec<Value>) -> Iter {
+    Iter {
+        iter: vec.clone().into_iter(),
+    }
+}
+
+// NB: decl_internal! prevents iterator from leaving the VM since the owned type
+// doesn't implement `FromValue`.
+decl_external!(Iter);
+
 /// Get the module for the array package.
 pub fn module() -> Result<Module, ContextError> {
     let mut module = Module::new(&["std", "vec"]);
 
     module.ty(&["Vec"]).build::<Vec<Value>>()?;
+    module.ty(&["Iter"]).build::<Iter>()?;
+
     module.function(&["Vec", "new"], Vec::<Value>::new)?;
+    module.inst_fn("iter", vec_iter)?;
     module.inst_fn("len", Vec::<Value>::len)?;
     module.inst_fn("push", Vec::<Value>::push)?;
     module.inst_fn("clear", Vec::<Value>::clear)?;
     module.inst_fn("pop", Vec::<Value>::pop)?;
+    module.inst_fn(crate::NEXT, Iter::next)?;
     Ok(module)
 }

--- a/crates/runestick/src/value/mod.rs
+++ b/crates/runestick/src/value/mod.rs
@@ -88,6 +88,25 @@ pub enum Value {
 }
 
 impl Value {
+    /// Convert into a slot if it's stored in a slot.
+    #[inline]
+    pub fn into_slot(self) -> Option<Slot> {
+        match self {
+            Self::String(slot) => Some(slot),
+            Self::Bytes(slot) => Some(slot),
+            Self::Vec(slot) => Some(slot),
+            Self::Tuple(slot) => Some(slot),
+            Self::Object(slot) => Some(slot),
+            Self::External(slot) => Some(slot),
+            Self::Future(slot) => Some(slot),
+            Self::Option(slot) => Some(slot),
+            Self::Result(slot) => Some(slot),
+            Self::TypedTuple(slot) => Some(slot),
+            Self::TypedObject(slot) => Some(slot),
+            _ => None,
+        }
+    }
+
     /// Try to coerce value reference into a result.
     #[inline]
     pub fn into_result(self, vm: &Vm) -> Result<Slot, VmError> {
@@ -236,12 +255,6 @@ impl Value {
                 ValueTypeInfo::TypedTuple(ty)
             }
         })
-    }
-}
-
-impl Default for Value {
-    fn default() -> Self {
-        Self::Unit
     }
 }
 

--- a/crates/runestick/src/vm/inst.rs
+++ b/crates/runestick/src/vm/inst.rs
@@ -286,13 +286,24 @@ pub enum Inst {
         /// The number of entries in the stack to pop.
         count: usize,
     },
-    /// Push a variable from a location `offset` relative to the current call
+    /// Copy a variable from a location `offset` relative to the current call
     /// frame.
     ///
-    /// A copy is very cheap. It simply means pushing a reference to the stack
-    /// and increasing a reference count.
+    /// A copy is very cheap. It simply means pushing a reference to the stack.
     Copy {
         /// Offset to copy value from.
+        offset: usize,
+    },
+    /// Drop the value in the given frame offset, cleaning out it's slot in
+    /// memory.
+    ///
+    /// # Operation
+    ///
+    /// ```text
+    /// => *noop*
+    /// ```
+    Drop {
+        /// Frame offset to drop.
         offset: usize,
     },
     /// Duplicate the value at the top of the stack.
@@ -758,6 +769,9 @@ pub enum Inst {
 impl fmt::Display for Inst {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Drop { offset } => {
+                write!(fmt, "drop {}", offset)?;
+            }
             Self::Not => {
                 write!(fmt, "not")?;
             }


### PR DESCRIPTION
Before this can be merged we need to figure out an ergonomical way to mark types which are safe to leave the VM, and types which are not.

It might be possible to do this using a trait, similar to `Unpin`, indicating that it is safe for a type to escape.
Unfortunately this trait must be unsafely implemented by callers.

Alternatively, taking a reference to the slice could panic. But this seems like an API hazard we'd like to not expose users to.